### PR TITLE
 Rewrite "Delegating work to blocking workers" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,14 +299,27 @@ There is some need for this potentially, as illustrated by the React usecase.
 
 ### Delegating work to blocking workers
 
-This is loosely based off an idea of "transactional JS". This would delegate work to the Host, who
-would run it in the context of a worker and block further execution until the result is ready.
-Objects which require manipulation would need to be isolated (read-only to the worker),
-and the modification could only be applied when the worker returns the result. This approach would
-not invalidate Run to Completion, as the guarentee provided by Run to Completion is that the data
-will not change in memory while the sync function runs unless it is changed by that function itself.
+One of the problem of the proposed solution is that all resources have to be loaded ahead, before
+doing a lazy initialization. Frameeworks have defined systems where the resources are not necessarily
+fetched yet, and if it is not fetched then the framework behave as-if we were doing a transaction, by
+unwinding everything and starting over.
 
-This leaves the issue of blocking the main thread.
+Today the main-thread cannot be blocked for multiple reasons. But we could block a worker thread as
+long as we do not break the run-to-completion restriction. The run-to-completion ensures that the amount
+of changes between 2 instructions remains bounded and known. We can easily add a `Promise.block()`
+function to any `Promise` which does not execute JavaScript code on the Worker thread.
+
+Thus, any code which is currently implemented as `sync` but depends on `Promise` resolution could be
+moved to a worker thread, and use `Promise.block()` for waiting on the completion of Promises which
+are either returning main-thread results computed asynchronously on the main-thread or returning
+result of fetch function which do not involve changing the state of the Worker thread.
+
+Once the worker work is completed, the data can be transfered back to the main thread by resolving a
+Promise.
+
+Some problems remains on how to efficiently transfer contextual information to the worker thread,
+without adding race conditions. To which some options might be to add a copy-on-write feature where
+any data transfered is preserved as read-only while a worker is potentially using it, or the opposite.
 
 ## Other Languages
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ There is some need for this potentially, as illustrated by the React usecase.
 ### Delegating work to blocking workers
 
 One of the problem of the proposed solution is that all resources have to be loaded ahead, before
-doing a lazy initialization. Frameeworks have defined systems where the resources are not necessarily
+doing a lazy initialization. Frameworks have defined systems where the resources are not necessarily
 fetched yet, and if it is not fetched then the framework behave as-if we were doing a transaction, by
 unwinding everything and starting over.
 
@@ -339,4 +339,3 @@ None so far.
 ## Q&A
 
 TODO.
-


### PR DESCRIPTION
Extend the description to explain why we could delegate work to a worker thread, and add a blocking `Promise.block()` function without breaking the run-to-completion semantic of JavaScript.